### PR TITLE
add -b flag to specify location of undocked vere binary

### DIFF
--- a/pkg/click/click
+++ b/pkg/click/click
@@ -69,7 +69,6 @@ full() {
         CUE_OPTS="$CUE_OPTS -k"
     fi
 
-    echo $EVAL_CMD
     $CLICK_CMD "$HOON" $DEPS |
         $EVAL_CMD eval --jam $JAM_OPTS |
         nc -U -W 1 "$PIER/.urb/conn.sock" |

--- a/pkg/click/click
+++ b/pkg/click/click
@@ -53,6 +53,7 @@ Usage:
     Thin client for interacting with running Urbit ship via conn.c
 
     options:
+        -b <path-to-vere>   Specify an undocked vere binary
         -e                  Execute jammed Hoon
         -h                  Show usage info
         -i <path-to-file>   Read input from file

--- a/pkg/click/click
+++ b/pkg/click/click
@@ -34,6 +34,7 @@ FILTER_GOOF=0
 JAM_HEX=0
 JAM_ONLY=0
 KHAN_TED=0
+EVAL_CMD=''
 
 INPUT=''
 OUTPUT=''
@@ -68,6 +69,7 @@ full() {
         CUE_OPTS="$CUE_OPTS -k"
     fi
 
+    echo $EVAL_CMD
     $CLICK_CMD "$HOON" $DEPS |
         $EVAL_CMD eval --jam $JAM_OPTS |
         nc -U -W 1 "$PIER/.urb/conn.sock" |
@@ -99,8 +101,11 @@ execute() {
 OPTIND=1
 
 # parse options
-while getopts ":ehi:jko:px" OPT; do
+while getopts ":b:ehi:jko:px" OPT; do
     case "$OPT" in
+        b)
+            EVAL_CMD=$OPTARG
+            ;;
         e)
             EXECUTE=1
             ;;
@@ -201,7 +206,10 @@ DEPS=$*
 if [[ $KHAN_TED -ne 0 ]]; then
     CLICK_CMD="$CLICK_CMD -k"
 fi
-EVAL_CMD="$PIER/.run"
+# use docked binary
+if [[ -z $EVAL_CMD ]]; then
+  EVAL_CMD="$PIER/.run"
+fi
 JAM_OPTS="-n"
 CUE_OPTS="-n"
 TMP_OUT=`mktemp -q --tmpdir`


### PR DESCRIPTION
Shouldn't be neccesarry to use click-format when using an undocked vere binary.