### PR TITLE
click: make it work on macOS too

### DIFF
--- a/pkg/click/click
+++ b/pkg/click/click
@@ -21,6 +21,15 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 SCRIPT_NAME=$(basename "$0")
 CLICK_CMD="$SCRIPT_DIR/click-format"
+# Determine OS
+OS_NAME="$(uname -s)"
+# Set netcat options based on OS
+if [[ "$OS_NAME" == "Darwin" ]]; then
+    NC_OPTS="-U"
+else
+    # For Linux and others where -W is supported
+    NC_OPTS="-U -W 1"
+fi
 
 # ==========================================================
 # VARIABLES
@@ -69,7 +78,7 @@ EOF
 full() {
     $CLICK_CMD "$HOON" $DEPS |
         $EVAL_CMD eval --jam $JAM_OPTS |
-        nc -U -W 1 "$PIER/.urb/conn.sock" |
+        nc $NC_OPTS "$PIER/.urb/conn.sock" |
         $EVAL_CMD eval --cue $CUE_OPTS
 }
 
@@ -82,7 +91,7 @@ jam() {
 }
 
 execute() {
-    nc -U -W 1 "$PIER/.urb/conn.sock" < $INPUT |
+    nc $NC_OPTS "$PIER/.urb/conn.sock" < $INPUT |
         $EVAL_CMD eval --cue $CUE_OPTS
 }
 
@@ -201,7 +210,10 @@ if [[ -n $INPUT ]]; then
 
     if [[ $EXECUTE -eq 0 ]]; then
         # read from file, escape 's, replace newlines w/ gaps
-        HOON="$(cat $INPUT | sed "s;';\\\\';g" | sed ':a;N;s/\n/  /;$!ba')"
+        # Previous approach, only works on Linux
+        # HOON="$(cat $INPUT | sed "s;';\\\\';g" | sed ':a;N;s/\n/  /;$!ba')"
+        # New approach, works on Linux and macOS
+        HOON="$(cat $INPUT | sed "s/'/\\\\'/g" | tr '\n' ' ')"
     fi
 else
     PIER=$1
@@ -223,7 +235,13 @@ if [[ -z $EVAL_CMD ]]; then
 fi
 JAM_OPTS="-n"
 CUE_OPTS="-n"
-TMP_OUT=`mktemp -q --tmpdir`
+if [[ "$OS_NAME" == "Darwin" ]]; then
+    # For macOS
+    TMP_OUT=$(mktemp -q /tmp/click.XXXXXX)
+else
+    # For Linux and others
+    TMP_OUT=$(mktemp -q --tmpdir)
+fi
 
 if [[ $JAM_ONLY -eq 0 ]]; then
     if [[ $FILTER_GOOF -ne 0 ]]; then

--- a/pkg/click/click-format
+++ b/pkg/click/click-format
@@ -100,7 +100,7 @@ while getopts ":hk" OPT; do
         \?)
             echo "Invalid option: -$OPTARG" >&2
             STATUS=1
-            ;&
+            ;;
         h)
             show_help
             exit "$STATUS"


### PR DESCRIPTION
Some minor changes to get it *mostly* working on macOS. Still seeing an issue with formatting (I think):

```
./click -k /Users/patrick/urbit/nalseg-banmud-finned-palmer - <<<"=/(m (strand ,vase) ;< ~ bind:m (poke [~dotdev-dotdev-finned-palmer %hood] %helm-hi ')) (pure:m \!>('success')))"
loom: mapped 2048MB
loom: mapped 2048MB
lite: arvo formula 2a2274c9
lite: arvo formula 2a2274c9
lite: core 4bb376f0
lite: final state 4bb376f0
eval (jam, newt):
lite: core 4bb376f0
lite: final state 4bb376f0
eval (cue, newt):
corrupted newt passed to cue
```